### PR TITLE
Bumpup 1.60.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ jobs:
   push_to_registry:
     name: Push Docker image to Github Packages
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       packages: write
       contents: read
     steps:
@@ -27,7 +27,6 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/rust-musl-builder:1.59.0
+            ghcr.io/${{ github.repository }}/rust-musl-builder:1.60.0
           build-args: |
-            TOOLCHAIN=1.59.0
-        
+            TOOLCHAIN=1.60.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && \
         libssl-dev \
         linux-libc-dev \
         pkgconf \
+        protobuf-compiler \
         sudo \
         xutils-dev \
         && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG OPENSSL_VERSION=1.1.1m
 # https://github.com/emk/rust-musl-builder/issues.
 ARG CARGO_ABOUT_VERSION=0.4.4
 ARG CARGO_DENY_VERSION=0.11.1
-ARG ZLIB_VERSION=1.2.11
+ARG ZLIB_VERSION=1.2.12
 ARG POSTGRESQL_VERSION=11.11
 
 # Make sure we have basic dev tools for building C libraries.  Our goal here is


### PR DESCRIPTION
## Why
Rust 1.60.0 にアップデートしたい。

また、prost 0.10.0 から protoc が同梱されなくなったため、
rust-musl-builder のイメージ内に protoc をインストールしてビルドが通るようにしたい。
https://github.com/tokio-rs/prost/releases/tag/v0.10.0

## What
- 1.60.0 のイメージが publish できるよう workflow の定義を更新しました
- prost 0.10.0 を利用できるよう protoc をインストールする記述を Dockerfile に追加しました

`cargo --version` と `protoc --version` が実行できたので問題なさそう

<img width="810" alt="スクリーンショット 2022-04-08 10 48 23" src="https://user-images.githubusercontent.com/3749175/162348400-7f4c12d6-3f8e-403e-b727-17e30a4187dd.png">
