### PR TITLE
feat: support cargo llvm-cov

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/rust-musl-builder:1.60.0
+            ghcr.io/${{ github.repository }}/rust-musl-builder:1.60.0-llvm-cov
           build-args: |
             TOOLCHAIN=1.60.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,9 @@ RUN curl https://sh.rustup.rs -sSf | \
     env CARGO_HOME=/opt/rust/cargo \
         rustup component add clippy && \
     env CARGO_HOME=/opt/rust/cargo \
-        rustup target add x86_64-unknown-linux-musl
+        rustup target add x86_64-unknown-linux-musl && \
+    env CARGO_HOME=/opt/rust/cargo \
+        rustup component add llvm-tools-preview
 ADD cargo-config.toml /opt/rust/cargo/config
 
 # Set up our environment variables so that we cross-compile using musl-libc by
@@ -163,6 +165,7 @@ ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
 # but cargo-deny provides a superset of cargo-audit's features.
 RUN env CARGO_HOME=/opt/rust/cargo cargo install -f cargo-audit && \
     env CARGO_HOME=/opt/rust/cargo cargo install -f cargo-deb && \
+    env CARGO_HOME=/opt/rust/cargo cargo install -f cargo-llvm-cov && \
     rm -rf /opt/rust/cargo/registry/
 
 # Allow sudo without a password.


### PR DESCRIPTION
Rust 1.60.0でsource-based code coverageが安定化されたため、カバレッジを測定する`cargo llvm-cov`を利用できるように修正しました。Docker tagはすでに`1.60.0`が存在しているため`1.60.0-llvm-cov`としてリリース予定です。
(次回以降元の命名に戻す予定です)