### PR TITLE
Feature/rust 1.62.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/rust-musl-builder:1.61.0-llvm-cov
+            ghcr.io/${{ github.repository }}/rust-musl-builder:1.62.0-llvm-cov
           build-args: |
-            TOOLCHAIN=1.61.0
+            TOOLCHAIN=1.62.0


### PR DESCRIPTION
- install latest from github releases instead of  `apt install protobuf-compiler` 
- bump up  Rust 1.62.0