### PR TITLE
ci: add a renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":label(renovate)",
+    ":semanticCommits",
+    ":timezone(Asia/Tokyo)",
+    "config:base"
+  ],
+  "dependencyDashboard": true,
+  "platformAutomerge": true,
+  "assignAutomerge": true,
+  "rebaseWhen": "auto",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "schedule": ["after 1am and before 9am every weekday"],
+  "prCreation": "not-pending",
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "['\"]?(?<currentValue>[^'\" \\n]+?)['\"]? +# renovate: depName=(?<depName>.*?)( extractVersion=(?<extractVersion>.*?))?\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^v(?<version>.*)${{/if}}"
+    }
+  ]
+}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,10 @@ name: Docker Image CI
 on:
   release:
     types: [published]
+
+env:
+  RUST_VERSION: 1.67.0  # renovate: depName=rust-lang/rust
+
 jobs:
   push_to_registry:
     name: Push Docker image to Github Packages
@@ -15,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Branch name
         id: branch_name
-        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
       - name: Log in to Github Docker Registry
         uses: docker/login-action@v1
         with:
@@ -27,6 +31,6 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/rust-musl-builder:1.67.0-llvm-cov
+            ghcr.io/${{ github.repository }}/rust-musl-builder:${{ env.RUST_VERSION }}-llvm-cov
           build-args: |
-            TOOLCHAIN=1.67.0
+            TOOLCHAIN=${{ env.RUST_VERSION }}


### PR DESCRIPTION
Why not install Renovate?
Renovate automatically creates Pull Requests for version updates.

TODO:
- ~We need to enable Renovate's GitHub App.~  enabled.
- We need to make sure that Renovate and workflow will work properly in the next Rust release.

---

@nrskt BTW, do we want the Docker tags back in their original format?
ref: https://github.com/caddijp/rust-musl-builder/pull/6